### PR TITLE
Add support for custom receive error handling

### DIFF
--- a/nfqueue_lt_1.12.go
+++ b/nfqueue_lt_1.12.go
@@ -128,7 +128,7 @@ func (nfqueue *Nfqueue) sendVerdicts() error {
 	return nil
 }
 
-func (nfqueue *Nfqueue) socketCallback(ctx context.Context, fn HookFunc, seq uint32) {
+func (nfqueue *Nfqueue) socketCallback(ctx context.Context, fn HookFunc, errfn ErrorFunc, seq uint32) {
 	defer func() {
 		// unbinding from queue
 		_, err := nfqueue.setConfig(uint8(unix.AF_UNSPEC), seq, nfqueue.queue, []netlink.Attribute{
@@ -149,13 +149,10 @@ func (nfqueue *Nfqueue) socketCallback(ctx context.Context, fn HookFunc, seq uin
 		}
 		replys, err := nfqueue.Con.Receive()
 		if err != nil {
-			if opError, ok := err.(*netlink.OpError); ok {
-				if opError.Timeout() || opError.Temporary() {
-					continue
-				}
+			if ret := errfn(err); ret != 0 {
+				return
 			}
-			nfqueue.logger.Printf("Could not receive message: %v\n", err)
-			return
+			continue
 		}
 		for _, msg := range replys {
 			if msg.Header.Type == netlink.Done {

--- a/types.go
+++ b/types.go
@@ -34,8 +34,12 @@ type Attribute struct {
 }
 
 // HookFunc is a function, that receives events from a Netlinkgroup
-// To stop receiving messages on this HookFunc, return something different than 0
+// To stop receiving messages on this HookFunc, return something different than 0.
 type HookFunc func(a Attribute) int
+
+// ErrorFunc is a function that receives all errors that happen while reading
+// from a Netlinkgroup. To stop receiving messages return something different than 0.
+type ErrorFunc func(e error) int
 
 // Config contains options for a Conn.
 type Config struct {


### PR DESCRIPTION
Hi Florian, first of all, thanks for this library! :rocket: 

This PR adds a new `RegisterWithErrorFunc` that allows to set a custom handler for netlink receive errors.

**Why is this needed**

We are parsing packets concurrently at https://github.com/safing/portmaster and and we are seeing lot's of i/o timeouts when setting a packet verdict using a 50ms WriteDeadline. IMHO we're hitting https://github.com/mdlayher/netlink/issues/136 as go-nfqueue blocks the netlink socket on [Conn.Receive() in socketCallback()](https://github.com/florianl/go-nfqueue/blob/master/nfqueue_gteq_1.12.go#L146). Since a timeout error causes the loop to immediately continue chances are good that the same goroutine re-acquires the socket lock and thus cause pending write operations to time out over and over again. 

**How to fix it**

Well, AFAIK we cannot actually fix that from this library but if we allow a custom error handler for errors returned in `Conn.Receive()` we can at least implement a work around by delaying the error handling until all pending write operations (or at least a batch of them) succeeded.

Or do you have another idea on how we could approach this issue? Looking forward to your feedback.