### PR TITLE
add ct labels support

### DIFF
--- a/types.go
+++ b/types.go
@@ -164,6 +164,8 @@ const (
 )
 
 // conntrack attributes
+// include/uapi/linux/netfilter/nfnetlink_conntrack.h
 const (
-	ctaMark = 8
+	ctaMark   = 8
+	ctaLabels = 22 // CTA_LABELS
 )


### PR DESCRIPTION
Add support to set CT labels, that is very useful for scenarios like kubernetes, see full context in https://lore.kernel.org/netfilter-devel/aPd6Ch7h6wdJa-eE@strlen.de/T/#mae18a8bb815a95d7bd8a496792bd6e0ee9029e00

and https://github.com/kubernetes-sigs/kube-network-policies/pull/268

This is basically a copy paste of SetVerdictWithConnMark and SetVerdictModPacketWithConnMark but passing the byte array directly.

I do not know if the kernel expects an specific format, it seems to me that only works with a 16 byte array, but I can not fully confirm that is the contract. In case that is the case we can do some input validation 