### PR TITLE
Added WithAlteredPacketHeader

### DIFF
--- a/nfqueue.go
+++ b/nfqueue.go
@@ -52,28 +52,28 @@ func (nfqueue *Nfqueue) SetVerdictWithLabel(id uint32, verdict int, label []byte
 //
 // Deprecated: Use SetVerdictWithOption() instead.
 func (nfqueue *Nfqueue) SetVerdictModPacket(id uint32, verdict int, packet []byte) error {
-	return nfqueue.SetVerdictWithOption(id, verdict, WithAlteredPacket(packet))
+	return nfqueue.SetVerdictWithOption(id, verdict, WithAlteredPayload(packet))
 }
 
 // SetVerdictModPacketWithMark signals the kernel the next action and mark for an altered packet
 //
 // Deprecated: Use SetVerdictWithOption() instead.
 func (nfqueue *Nfqueue) SetVerdictModPacketWithMark(id uint32, verdict, mark int, packet []byte) error {
-	return nfqueue.SetVerdictWithOption(id, verdict, WithMark(uint32(mark)), WithAlteredPacket(packet))
+	return nfqueue.SetVerdictWithOption(id, verdict, WithMark(uint32(mark)), WithAlteredPayload(packet))
 }
 
 // SetVerdictModPacketWithConnMark signals the kernel the next action and connmark for an altered packet
 //
 // Deprecated: Use SetVerdictWithOption() instead.
 func (nfqueue *Nfqueue) SetVerdictModPacketWithConnMark(id uint32, verdict, mark int, packet []byte) error {
-	return nfqueue.SetVerdictWithOption(id, verdict, WithConnMark(uint32(mark)), WithAlteredPacket(packet))
+	return nfqueue.SetVerdictWithOption(id, verdict, WithConnMark(uint32(mark)), WithAlteredPayload(packet))
 }
 
 // SetVerdictModPacketWithLabel signals the kernel the next action and label for an altered packet
 //
 // Deprecated: Use SetVerdictWithOption() instead.
 func (nfqueue *Nfqueue) SetVerdictModPacketWithLabel(id uint32, verdict int, label []byte, packet []byte) error {
-	return nfqueue.SetVerdictWithOption(id, verdict, WithAlteredPacket(packet), WithLabel(label))
+	return nfqueue.SetVerdictWithOption(id, verdict, WithAlteredPayload(packet), WithLabel(label))
 }
 
 // SetVerdict signals the kernel the next action for a specified package id

--- a/verdict.go
+++ b/verdict.go
@@ -58,11 +58,35 @@ func WithLabel(label []byte) VerdictOption {
 }
 
 // WithAlteredPacket sets the altered packet payload.
+//
+// Deprecated: Use WithAlteredPayload(payload []byte) instead.
 func WithAlteredPacket(packet []byte) VerdictOption {
 	return func(vo *verdictOptions) error {
 		vo.attrs = append(vo.attrs, netlink.Attribute{
 			Type: nfQaPayload,
 			Data: packet,
+		})
+		return nil
+	}
+}
+
+// WithAlteredPayload sets the altered packet payload.
+func WithAlteredPayload(payload []byte) VerdictOption {
+	return func(vo *verdictOptions) error {
+		vo.attrs = append(vo.attrs, netlink.Attribute{
+			Type: nfQaPayload,
+			Data: payload,
+		})
+		return nil
+	}
+}
+
+// WithAlteredPacketHeader sets the altered packet header.
+func WithAlteredPacketHeader(header []byte) VerdictOption {
+	return func(vo *verdictOptions) error {
+		vo.attrs = append(vo.attrs, netlink.Attribute{
+			Type: nfQaPacketHdr,
+			Data: header,
 		})
 		return nil
 	}


### PR DESCRIPTION
Added a `WithAlteredPacketHeader` function. 
`WithAlteredPacket` is slightly misleading (although clear from implementation and doc string). I added a renamed version (`WithAlteredPayload`) and deprecated the `WithAlteredPacket`. This might be controversial.
Did you consider supporting a package user to define their own `VerdictOption`?