### PR TITLE
Add integration test for nfqueue packet path

### DIFF
--- a/nfqueue_linux_integration_test.go
+++ b/nfqueue_linux_integration_test.go
@@ -5,7 +5,12 @@ package nfqueue
 
 import (
 	"context"
+	"net"
 	"os/exec"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -98,4 +103,91 @@ func TestTimeout(t *testing.T) {
 
 	// Block till the context expires
 	<-ctx.Done()
+}
+
+func TestNfqueuePacketPath(t *testing.T) {
+	if err := syscall.Unshare(syscall.CLONE_NEWNET); err != nil {
+		t.Fatalf("failed to unshare network namespace: %v", err)
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Bring up the loopback interface so that packets can be sent through the nfqueue path.
+	if out, err := exec.Command("ip", "link", "set", "lo", "up").CombinedOutput(); err != nil {
+		t.Fatalf("failed to bring lo up: %v: %s", err, out)
+	}
+
+	nftRules := strings.NewReader(`
+table inet test-nfqueue {
+	chain output {
+		type filter hook output priority 0; policy accept;
+		queue num 200
+	}
+}
+`)
+	cmd := exec.Command("nft", "-f", "-")
+	cmd.Stdin = nftRules
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to set up nftables: %v: %s", err, out)
+	}
+
+	nfq, err := Open(&Config{
+		NfQueue:      200,
+		MaxPacketLen: 0xFFFF,
+		MaxQueueLen:  0xFF,
+		Copymode:     NfQnlCopyPacket,
+		WriteTimeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to open nfqueue: %v", err)
+	}
+	defer nfq.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var callbackFired atomic.Bool
+	err = nfq.RegisterWithErrorFunc(ctx, func(a Attribute) int {
+		callbackFired.Store(true)
+		nfq.SetVerdict(*a.PacketID, NfAccept)
+		return 0
+	}, func(err error) int {
+		// Timeouts return an error "netlink receive: use of closed file".
+		// This is a workaround to avoid treating timeouts as test failures.
+		if ctx.Err() == nil {
+			t.Errorf("nfqueue error: %v", err)
+		}
+		return 0
+	})
+	if err != nil {
+		t.Fatalf("failed to register: %v", err)
+	}
+
+	// Listen on a UDP port to receive the packet that will be sent through the nfqueue path
+	listener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer listener.Close()
+	listener.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	// Send a UDP packet to trigger the nfqueue callback
+	conn, err := net.Dial("udp", listener.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	conn.Write([]byte("test-packet"))
+	conn.Close()
+
+	buf := make([]byte, 256)
+	n, _, err := listener.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("packet not delivered (nfqueue receive/verdict broken): %v", err)
+	}
+	if got := string(buf[:n]); got != "test-packet" {
+		t.Errorf("received %q, want %q", got, "test-packet")
+	}
+	if !callbackFired.Load() {
+		t.Error("nfqueue callback was never invoked")
+	}
 }


### PR DESCRIPTION
Add TestNfqueuePacketPath, which verifies that packets flow through nfqueue and are delivered after a verdict is issued.

A UDP packet is sent over loopback, intercepted by nfqueue, accepted via SetVerdict, and then received by a UDP listener. The test asserts that the callback fires and the packet is delivered with the correct payload.

The test currently fails with mdlayher/netlink v1.11.0 due to a bug in netlink.Message.UnmarshalBinary rejecting valid unaligned netlink messages.