### PR TITLE
Issue 112: Fix small typo in 'NfQeueue'

### DIFF
--- a/nfqueue.go
+++ b/nfqueue.go
@@ -308,7 +308,7 @@ func (nfqueue *Nfqueue) setVerdict(id uint32, verdict int, batch bool, attribute
 		};
 	*/
 
-	if verdict != NfDrop && verdict != NfAccept && verdict != NfStolen && verdict != NfQeueue && verdict != NfRepeat {
+	if verdict != NfDrop && verdict != NfAccept && verdict != NfStolen && verdict != NfQueue && verdict != NfRepeat {
 		return ErrInvalidVerdict
 	}
 

--- a/types.go
+++ b/types.go
@@ -160,9 +160,14 @@ const (
 	NfDrop = iota
 	NfAccept
 	NfStolen
-	NfQeueue
+	NfQueue
 	NfRepeat
 )
+
+// NfQeueue is a deprecated incorrect spelling of NfQueue.
+// This is only present to prevent breaking compatibility.
+// see https://github.com/florianl/go-nfqueue/issues/112
+const NfQeueue = NfQueue
 
 // conntrack attributes
 // include/uapi/linux/netfilter/nfnetlink_conntrack.h

--- a/types.go
+++ b/types.go
@@ -165,8 +165,7 @@ const (
 )
 
 // NfQeueue is a deprecated incorrect spelling of NfQueue.
-// This is only present to prevent breaking compatibility.
-// see https://github.com/florianl/go-nfqueue/issues/112
+// Deprecated: Please migrate to NfQueue.
 const NfQeueue = NfQueue
 
 // conntrack attributes


### PR DESCRIPTION
This passes lint checks locally and should close issue #112

https://github.com/florianl/go-nfqueue/issues/112